### PR TITLE
Add basic tests and CI configuration using github actions

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,24 @@
+name: key4hep
+
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
+      with:
+        container: centos7
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_INSTALL_PREFIX=../install \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
+            -GNinja ..
+          ninja -k0

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -22,3 +22,5 @@ jobs:
             -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always -Werror " \
             -GNinja ..
           ninja -k0
+          ninja install
+          ctest --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ install
 
 # Python cache files
 *.pyc
+
+# Common output file types
+*.root
+*.slcio

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+# Canonical build folders
+build
+spack*
+install
+
+# Editor swap files
+*~
+*.swp
+
+# Tooling
+/.clangd/
+/compile_commands.json
+.vscode
+
 # Prerequisites
 *.d
 
@@ -30,3 +44,6 @@
 *.exe
 *.out
 *.app
+
+# Python cache files
+*.pyc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,6 @@ target_link_libraries(${PROJECT_NAME} DD4hep::DDCore)
 
 # Create this_package.sh file, and install
 dd4hep_instantiate_package(${PROJECT_NAME})
+
+include(CTest)
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,24 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
-set(PackageName luxegeo)
-project(${PackageName})
+
+project(luxegeo)
+
+# project version
+SET( ${PROJECT_NAME}_VERSION_MAJOR 0 )
+SET( ${PROJECT_NAME}_VERSION_MINOR 0 )
+SET( ${PROJECT_NAME}_VERSION_PATCH 0 )
+
+SET( ${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
+
 find_package(DD4hep REQUIRED COMPONENTS DDG4)
-# our sources
-set(sources ./src/SimpleTracker_geo.cpp ./src/LUXETracker_geo.cpp)
 # create our library and make the components file
-add_dd4hep_plugin(${PackageName} SHARED ${sources}) # link it with DDCore, or whatever you need
-target_link_libraries(${PackageName} DD4hep::DDCore)
+# our sources
+set(sources
+  ./src/SimpleTracker_geo.cpp
+  ./src/LUXETracker_geo.cpp
+  )
+
+add_dd4hep_plugin(${PROJECT_NAME} SHARED ${sources}) # link it with DDCore, or whatever you need
+target_link_libraries(${PROJECT_NAME} DD4hep::DDCore)
+
 # Create this_package.sh file, and install
-dd4hep_instantiate_package(${PackageName})
+dd4hep_instantiate_package(${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -1,0 +1,105 @@
+# luxegeo
+
+[![key4hep](https://github.com/LUXEsoftware/luxegeo/actions/workflows/key4hep.yml/badge.svg)](https://github.com/LUXEsoftware/luxegeo/actions/workflows/key4hep.yml)
+
+Implementation of the detector geometry of the LUXE experiment using [DD4hep](https://dd4hep.web.cern.ch/dd4hep/).
+
+## Requirements
+luxegeo needs to be built against DD4hep with Geant4 enabled and a c++ compiler
+supporting c++17. It is tested regularly in a continuous integration (CI)
+workflow against [Key4hep](https://key4hep.web.cern.ch).
+
+## Download and Installation
+### Download
+To get the latest version of luxegeo simply clone this repository
+
+```bash
+git clone https://github.com/LUXESoftware/luxegeo
+```
+
+or download and unpack a release tarball from github (see [Releases](https://github.com/LUXEsoftware/luxegeo/releases)).
+
+### Setting up the dependencies
+There are several ways of setting up the necessary dependencies for building and
+installing luxegeo, the main is to use a Key4hep software stack, which requires
+a `/cvmfs/` mount and CentOS7.
+
+#### Using a Key4hep software stack
+A Key4hep software stack comes with all dependencies fulfilled. Hence, sourcing
+the setup script is enough, e.g.
+
+```bash
+source /cvmfs/sw.hsf.org/key4hep/setup.sh
+```
+
+Replacing `sw.hsf.org` by `sw-nightlies.hsf.org` will setup the bleeding edge
+version of the Key4hep stack that is built nightly. This setup is less stable,
+but might offer some fixes that have not yet landed in the proper releases on
+`sw.hsf.org`.
+
+<details>
+  <summary>Instructions for other options</summary>
+
+#### Using an LCG software stack
+Similar to the Key4hep stack it is possible to use an LCG software stack that
+also comes with all depenencies fulfilled. These releases are available or
+different linux flavors and compilers, and again sourcing the approriate setup
+script is enough, e.g.
+
+```bash
+source /cvmfs/sft.cern.ch/lcg/views/LCG_102/x86_64-centos7-gcc11-opt/setup.sh
+```
+
+#### Using an existing DD4hep installation
+If you have an existing installation of DD4hep on your system, it should be
+enough to initialize that via
+
+```bash
+source </path/to/dd4hep/installation>/bin/thisdd4hep.sh
+```
+
+</details>
+
+### Building and installing luxegeo
+luxegeo is a CMake project, so building it follows the usual steps
+
+```bash
+cd luxegeo
+mkdir build && cd build
+cmake -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_INSTALL_PREFIX=../install
+  ..
+make install
+```
+
+luxegeo comes with a few tests to verify that the build and installation process
+has been successful, they can be run via (in the `build` folder)
+
+```bash
+ctest --output-on-failure
+```
+
+### Running a simple example using a particle gun
+After luxegeo has been installed, it is possible to run a simple simulation. In
+the following we assume that you are in the `luxegeo` base directory, and that
+the build artifacts are installed to `install` (this is what you get from
+following the [build instructions](#building-and-installing-luxegeo)) The first
+step is to setup luxegeo.
+
+```bash
+source install/bin/thisluxegeo.sh
+```
+
+We then use `ddsim` to run a simulation using the LUXE tracker. The example uses
+a particle gun to shoot 100 positrons in one shot and produces an output in
+EDM4hep format. (Note, that you need DD4hep that has been built with EDM4hep
+enabled)
+
+```bash
+ddsim --compactFile xml/LUXETracker.xml \
+  --numberOfEvents 1 \
+  --enableGun \
+  --gun.multiplicity 100 \
+  --gun.particle e+ \
+  --outputFile positrons_tracker_edm4hep.root
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(PackageName ${PROJECT_NAME})
+
+configure_file(${DD4hep_ROOT}/cmake/run_test_package.sh run_test_${PackageName}.sh @ONLY)
+install(PROGRAMS
+  ${CMAKE_CURRENT_BINARY_DIR}/run_test_${PackageName}.sh
+  DESTINATION bin)
+
+# Helper function to quickly write tests for luxegeo. It takes care of setting
+# up the correct environment and also to register it with CTest. The resulting
+# tests will fail if the command fails or if it prints anything pointing towards
+# a runtime error to screen
+#
+# Arguments:
+#   name        The name of the test (as it will also appear in the CTest output)
+#   command     The command to run
+function(LUXEGEO_TEST name)
+  add_test(${name} "${CMAKE_INSTALL_PREFIX}/bin/run_test_${PackageName}.sh"
+    ${ARGN})
+  set_tests_properties(${name}
+    PROPERTIES
+      FAIL_REGULAR_EXPRESSION "Exception;EXCEPTION;ERROR;Error"
+    )
+endfunction()
+
+LUXEGEO_TEST(test_SimpleTracker ddsim --compactFile ${CMAKE_SOURCE_DIR}/xml/SimpleTracker.xml -G -N 1 --gun.multiplicity 100 --gun.particle e+)
+
+LUXEGEO_TEST(test_LUXETracker ddsim --compactFile ${CMAKE_SOURCE_DIR}/xml/LUXETracker.xml -G -N 1 --gun.multiplicity 100 --gun.particle e+)


### PR DESCRIPTION
This PR adds
- Basic version information in the CMake configuration
- A basic setup for running tests via `ctest`
- A basic CI setup in which everything is built and the tests are run using github actions
- Add a basic README with instructions on how to build and run a simple example

FYI @madbaron 