### PR TITLE
Add simple particle gun based tests for the calorimeters

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,14 @@ function(LUXEGEO_TEST name)
     )
 endfunction()
 
-LUXEGEO_TEST(test_SimpleTracker ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/SimpleTracker.xml -G -N 1 --gun.multiplicity 100 --gun.particle e+)
+LUXEGEO_TEST(test_SimpleTracker
+  ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/SimpleTracker.xml
+  -G -N 1 --gun.multiplicity 100 --gun.particle e+
+  --outputFile ddsim_simple_tracker.root
+)
 
-LUXEGEO_TEST(test_LUXETracker ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/LUXETracker.xml -G -N 1 --gun.multiplicity 100 --gun.particle e+)
+LUXEGEO_TEST(test_LUXETracker
+  ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/LUXETracker.xml
+  -G -N 1 --gun.multiplicity 100 --gun.particle e+
+  --outputFile ddsim_luxe_tracker.root
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,3 +33,17 @@ LUXEGEO_TEST(test_LUXETracker
   -G -N 1 --gun.multiplicity 100 --gun.particle e+
   --outputFile ddsim_luxe_tracker.root
 )
+
+LUXEGEO_TEST(test_ECALp
+  ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/ECALp_luxe/ECALp_luxe_2512.xml
+  -G -N 1 --gun.multiplicity 100 --gun.particle e+
+  --gun.position=0,0,-50 --gun.direction=0,0,1
+  --outputFile ddsim_luxe_ecalp.root
+)
+
+LUXEGEO_TEST(test_ECALe
+  ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/ECALe_luxe/ECALe_luxe_2512.xml
+  -G -N 1 --gun.multiplicity 100 --gun.particle e-
+  --gun.position=0,0,-250 --gun.direction=0,0,1
+  --outputFile ddsim_luxe_ecale.root
+)


### PR DESCRIPTION
This PR simply adds two additional tests that shoot a particle gun with fixed position and direction into (effectively) the center of the calorimeters.

@shan-yamabuki could you confirm that my chosen z-position for the guns (i.e. `(0, 0, -50)` for ECALp and `(0, 0, -250)` for ECALe) are somewhat sensible?