### PR TITLE
Make an integrated geometry with a tracker and the ECALp

### DIFF
--- a/compact/LUXE/ECALp/ECALp_2512.xml
+++ b/compact/LUXE/ECALp/ECALp_2512.xml
@@ -22,6 +22,10 @@
 
   <define>
     <include ref="../basic_defs.xml"/>
+    <include ref="../ECAL_commondefs.xml" />
+    <include ref="./ECALp_defs.xml"/>
+    <include ref="../ECAL_commondisp.xml" />
+    <include ref="./ECALp_standalone_defs.xml"/>
   </define>
 
 
@@ -31,103 +35,6 @@
     </limitset>
   </limits>
 
-  <define>
-    <include ref="../ECAL_commondefs.xml" />
-    <include ref="./ECALp_defs.xml"/>
-    <include ref="../ECAL_commondisp.xml" />
-  </define>
+  <include ref="./ECALp_v0.xml"/>
 
-  <readouts>
-    <readout name="SiEcalCollection">
-      <!--We are making a very simple segmentation: one single tile that takes the full surface of every layer "/-->
-      <segmentation type="TiledLayerGridXY"
-          grid_size_x="EcalP_dim_x*2"
-          grid_size_y="EcalP_dim_y*2"
-          offset_x="-(EcalP_dim_x)/2.0"
-          offset_y="-(EcalP_dim_y)/2.0" />
-      <id>system:8,layer:8,x:16,y:16,slice:8,module:4</id>
-    </readout>
-    <readout name="PixelSiEcalCollection">
-      <segmentation type="TiledLayerGridXY"
-          grid_size_x="5.53*mm"
-          grid_size_y="5.53*mm"
-          offset_x="-44.24*mm"
-          offset_y="-44.24*mm" />
-      <id>system:8,layer:5,slice:4,module:3,x:4,y:4</id>
-    </readout>
-    <readout name="PixelSiEcalCollectionCart">
-      <!-- Cartesian type not working -->
-      <segmentation type="CartesianGridXY"
-          grid_size_x="5.53*mm"
-          grid_size_y="5.53*mm"
-          offset_x="-44.24*mm"
-          offset_y="-44.24*mm" />
-      <id>system:8,layer:5,slice:4,module:3,x:4,y:4</id>
-    </readout>
-  </readouts>
-
-  <detectors>
-    <detector name="ECALp_luxe" type="LUXEEcal" vis="EcalVis" id="2000" readout="PixelSiEcalCollection" insideTrackingVolume="false">
-      <dimensions
-          x="EcalP_dim_x"
-          y="EcalP_dim_y"
-          z="EcalP_dim_z" />
-      <type_flags type="1" />
-      <envelope vis="EcalVis">
-        <shape type="Box"
-            dx="EcalP_dim_x/2.0 + env_safety"
-            dy="EcalP_dim_y/2.0 + env_safety"
-            dz="EcalP_dim_z/2.0 + env_safety"
-            material="Air" />
-        <rotation x="0" y="0" z="0" />
-        <position x="0" y="0" z="EcalP_dim_z/2.0" />
-      </envelope>
-
-
-      <layer repeat="20" vis="EcalVis">
-        <slice material="TungstenDens1910"  thickness="EcalP_WThickness" vis="TungstenVis" /> <!-- 2x2.1mm of tungsten in each layer-->
-        <slice material="CarbonFiber"       thickness="Ecal_CFThickness250"  vis="AirVis" sliceHasModules="true">
-          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
-          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
-          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
-          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
-          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
-          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
-        </slice>
-        <slice material="Air"               thickness="0.5*Ecal_GlueThickness_kap" vis="AirVis" />
-        <slice material="Cu"                thickness="Ecal_KaptonThickness" vis="AirVis" sliceHasModules="true">
-          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-        </slice>
-        <slice material="Air"               thickness="0.5*Ecal_GlueThickness_kap" vis="AirVis" />
-        <slice material="Si"                thickness="Ecal_WaferThickness320" vis="AirVis" sliceHasModules="true" sensitive="yes">
-          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
-          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
-          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
-          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
-          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
-          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
-        </slice>
-        <slice material="Air"               thickness="0.5*Ecal_GlueThickness_kap" vis="AirVis" />
-        <slice material="Cu"                thickness="Ecal_KaptonThickness" vis="AirVis" sliceHasModules="true">
-          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
-        </slice>
-        <slice material="Air"               thickness="EcalP_Airgap" vis="AirVis" />
-      </layer>
-      <!-- Last "layer" as a protection/shielding from the rear -->
-      <layer repeat="1" vis="EcalVis">
-        <slice material="TungstenDens1910"  thickness="EcalP_WThickness" vis="TungstenVis" />
-      </layer>
-
-    </detector>
-  </detectors>
 </lccdd>

--- a/compact/LUXE/ECALp/ECALp_standalone_defs.xml
+++ b/compact/LUXE/ECALp/ECALp_standalone_defs.xml
@@ -1,0 +1,5 @@
+<define>
+  <constant name="EcalP_x_position" value="0*mm"/>
+  <constant name="EcalP_y_position" value="0*mm"/>
+  <constant name="EcalP_z_position" value="EcalP_dim_z / 2.0"/>
+</define>

--- a/compact/LUXE/ECALp/ECALp_v0.xml
+++ b/compact/LUXE/ECALp/ECALp_v0.xml
@@ -43,7 +43,7 @@
             dz="EcalP_dim_z/2.0 + env_safety"
             material="Air" />
         <rotation x="0" y="0" z="0" />
-        <position x="EcalP_x_position" y="EcalP_y_position" z="EcalP_z_position" />
+        <position x="EcalP_x_position + EcalP_dim_x / 2" y="EcalP_y_position" z="EcalP_z_position + EcalP_dim_z / 2" />
       </envelope>
 
 

--- a/compact/LUXE/ECALp/ECALp_v0.xml
+++ b/compact/LUXE/ECALp/ECALp_v0.xml
@@ -1,0 +1,99 @@
+<lccdd>
+  <readouts>
+    <readout name="SiEcalCollection">
+      <!--We are making a very simple segmentation: one single tile that takes the full surface of every layer "/-->
+      <segmentation type="TiledLayerGridXY"
+          grid_size_x="EcalP_dim_x*2"
+          grid_size_y="EcalP_dim_y*2"
+          offset_x="-(EcalP_dim_x)/2.0"
+          offset_y="-(EcalP_dim_y)/2.0" />
+      <id>system:8,layer:8,x:16,y:16,slice:8,module:4</id>
+    </readout>
+    <readout name="PixelSiEcalCollection">
+      <segmentation type="TiledLayerGridXY"
+          grid_size_x="5.53*mm"
+          grid_size_y="5.53*mm"
+          offset_x="-44.24*mm"
+          offset_y="-44.24*mm" />
+      <id>system:8,layer:5,slice:4,module:3,x:4,y:4</id>
+    </readout>
+    <readout name="PixelSiEcalCollectionCart">
+      <!-- Cartesian type not working -->
+      <segmentation type="CartesianGridXY"
+          grid_size_x="5.53*mm"
+          grid_size_y="5.53*mm"
+          offset_x="-44.24*mm"
+          offset_y="-44.24*mm" />
+      <id>system:8,layer:5,slice:4,module:3,x:4,y:4</id>
+    </readout>
+  </readouts>
+
+
+  <detectors>
+    <detector name="ECALp_luxe" type="LUXEEcal" vis="EcalVis" id="2000" readout="PixelSiEcalCollection" insideTrackingVolume="false">
+      <dimensions
+          x="EcalP_dim_x"
+          y="EcalP_dim_y"
+          z="EcalP_dim_z" />
+      <type_flags type="1" />
+      <envelope vis="EcalVis">
+        <shape type="Box"
+            dx="EcalP_dim_x/2.0 + env_safety"
+            dy="EcalP_dim_y/2.0 + env_safety"
+            dz="EcalP_dim_z/2.0 + env_safety"
+            material="Air" />
+        <rotation x="0" y="0" z="0" />
+        <position x="EcalP_x_position" y="EcalP_y_position" z="EcalP_z_position" />
+      </envelope>
+
+
+      <layer repeat="20" vis="EcalVis">
+        <slice material="TungstenDens1910"  thickness="EcalP_WThickness" vis="TungstenVis" /> <!-- 2x2.1mm of tungsten in each layer-->
+        <slice material="CarbonFiber"       thickness="Ecal_CFThickness250"  vis="AirVis" sliceHasModules="true">
+          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
+          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
+          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
+          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
+          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
+          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="89.99*mm" dy="89.99*mm"   vis="CFVis" />
+        </slice>
+        <slice material="Air"               thickness="0.5*Ecal_GlueThickness_kap" vis="AirVis" />
+        <slice material="Cu"                thickness="Ecal_KaptonThickness" vis="AirVis" sliceHasModules="true">
+          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+        </slice>
+        <slice material="Air"               thickness="0.5*Ecal_GlueThickness_kap" vis="AirVis" />
+        <slice material="Si"                thickness="Ecal_WaferThickness320" vis="AirVis" sliceHasModules="true" sensitive="yes">
+          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
+          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
+          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
+          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
+          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
+          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="88.48*mm" dy="88.48*mm"   vis="SiVis" />
+        </slice>
+        <slice material="Air"               thickness="0.5*Ecal_GlueThickness_kap" vis="AirVis" />
+        <slice material="Cu"                thickness="Ecal_KaptonThickness" vis="AirVis" sliceHasModules="true">
+          <module id="0"   x_offset="-225.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="1"   x_offset="-135.0*mm" y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="2"   x_offset="-45.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="3"   x_offset="45.0*mm"   y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="4"   x_offset="135.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+          <module id="5"   x_offset="225.0*mm"  y_offset="0.0*mm"   dx="89.7*mm" dy="89.7*mm"   vis="CuVis" />
+        </slice>
+        <slice material="Air"               thickness="EcalP_Airgap" vis="AirVis" />
+      </layer>
+      <!-- Last "layer" as a protection/shielding from the rear -->
+      <layer repeat="1" vis="EcalVis">
+        <slice material="TungstenDens1910"  thickness="EcalP_WThickness" vis="TungstenVis" />
+      </layer>
+
+    </detector>
+  </detectors>
+
+  
+  
+</lccdd>

--- a/compact/LUXE/LUXE_v0.xml
+++ b/compact/LUXE/LUXE_v0.xml
@@ -1,0 +1,33 @@
+<lccdd>
+  <info name="LUXE DD4hep geometry"
+        title="LUXE_v0"
+        author="LUXE collaboration"
+        url="luxe.desy.de"
+        status="development"
+        version="v0">
+    <comment>
+      This is an active development geometry of the LUXE geometry implemented in
+      DD4hep. The focus is on bringing as many sensitive detectors in without
+      support first.
+    </comment>
+  </info>
+
+  <includes>
+    <gdmlFile ref="./elements.xml"/>
+    <gdmlFile ref="./materials.xml"/>
+  </includes>
+
+  <define>
+    <include ref="./basic_defs.xml"/>
+  </define>
+
+  <include ref="./dipole_field.xml"/>
+  <include ref="Tracker/Tracker_v0.xml"/>
+
+  <!-- TODO: Split existing ecal geometry into a part that can be
+       included here and another one that also includes that part, but remains
+       usable in a standalone fashion. Make sure to position it correctly.
+  -->
+
+
+</lccdd>

--- a/compact/LUXE/LUXE_v0.xml
+++ b/compact/LUXE/LUXE_v0.xml
@@ -19,15 +19,21 @@
 
   <define>
     <include ref="./basic_defs.xml"/>
+    <include ref="./detector_positions.xml"/>
+    <include ref="./ECAL_commondefs.xml"/>
+    <include ref="./ECAL_commondisp.xml" />
+    <include ref="./ECALp/ECALp_defs.xml"/>
   </define>
+
+  <limits>
+    <limitset name="cal_limits">
+      <limit name="step_length_max" particles="*" value="5.0" unit="mm" />
+    </limitset>
+  </limits>
+
 
   <include ref="./dipole_field.xml"/>
   <include ref="Tracker/Tracker_v0.xml"/>
-
-  <!-- TODO: Split existing ecal geometry into a part that can be
-       included here and another one that also includes that part, but remains
-       usable in a standalone fashion. Make sure to position it correctly.
-  -->
-
+  <include ref="ECALp/ECALp_v0.xml"/>
 
 </lccdd>

--- a/compact/LUXE/LUXE_v0.xml
+++ b/compact/LUXE/LUXE_v0.xml
@@ -36,4 +36,17 @@
   <include ref="Tracker/Tracker_v0.xml"/>
   <include ref="ECALp/ECALp_v0.xml"/>
 
+  <!-- For older DD4hep versions (e.g. 1.32) it is necessary to have the plugins
+       here at the end. They cannot be included from a common xml file.-->
+  <plugins>
+    <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+      <argument value="Tracker"/>
+      <argument value="dimension=2"/>
+      <argument value="u_x=1."/>
+      <argument value="v_y=1."/>
+      <argument value="n_z=1."/>
+    </plugin>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
+
 </lccdd>

--- a/compact/LUXE/Tracker/LUXETracker.xml
+++ b/compact/LUXE/Tracker/LUXETracker.xml
@@ -16,6 +16,7 @@
 
   <define>
     <include ref="../basic_defs.xml"/>
+    <include ref="./tracker_defs.xml"/>
   </define>
 
   <detectors>

--- a/compact/LUXE/Tracker/LUXETracker.xml
+++ b/compact/LUXE/Tracker/LUXETracker.xml
@@ -16,58 +16,9 @@
 
   <define>
     <include ref="../basic_defs.xml"/>
-    <include ref="./tracker_defs.xml"/>
   </define>
 
-  <detectors>
-    <detector name="Tracker" type="LUXETracker" readout="SiHits" insideTrackingVolume="true">
-      <layer id="1" x="290*mm" y="0" z="3956*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
-      </layer>
-      <layer id="2" x="290*mm" y="0" z="4056*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
-      </layer>
-      <layer id="3" x="290*mm" y="0" z="4156*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
-      </layer>
-      <layer id="4" x="290*mm" y="0" z="4256*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
-      </layer>
-    </detector>
-  </detectors>
-
-  <readouts>
-    <readout name="SiHits">
-      <segmentation type="CartesianGridXY" grid_size_x="0.025*mm" grid_size_y="0.025*mm"/>
-      <id>${GlobalTrackerReadoutID}</id>
-    </readout>
-  </readouts>
-
   <include ref="../dipole_field.xml"/>
-
-  <plugins>
-    <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
-      <argument value="Tracker"/>
-      <argument value="dimension=2"/>
-      <argument value="u_x=1."/>
-      <argument value="v_y=1."/>
-      <argument value="n_z=1."/>
-    </plugin>
-    <plugin name="InstallSurfaceManager"/>
-  </plugins>
-
-  <display>
-    <vis name="SolidRed"  r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
-    <vis name="Red"  alpha="0.1" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
-    <vis name="Invisible" showDaughters="true" visible="false"/>
-  </display>
+  <include ref="./Tracker_v0.xml"/>
 
 </lccdd>

--- a/compact/LUXE/Tracker/LUXETracker.xml
+++ b/compact/LUXE/Tracker/LUXETracker.xml
@@ -21,4 +21,17 @@
   <include ref="../dipole_field.xml"/>
   <include ref="./Tracker_v0.xml"/>
 
+  <!-- For older DD4hep versions (e.g. 1.32) it is necessary to have the plugins
+       here at the end. They cannot be included from a common xml file.-->
+  <plugins>
+    <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+      <argument value="Tracker"/>
+      <argument value="dimension=2"/>
+      <argument value="u_x=1."/>
+      <argument value="v_y=1."/>
+      <argument value="n_z=1."/>
+    </plugin>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
+
 </lccdd>

--- a/compact/LUXE/Tracker/LUXETracker.xml
+++ b/compact/LUXE/Tracker/LUXETracker.xml
@@ -16,6 +16,7 @@
 
   <define>
     <include ref="../basic_defs.xml"/>
+    <include ref="../detector_positions.xml"/> <!-- Only need the ones from the tracker -->
   </define>
 
   <include ref="../dipole_field.xml"/>

--- a/compact/LUXE/Tracker/Tracker_v0.xml
+++ b/compact/LUXE/Tracker/Tracker_v0.xml
@@ -5,25 +5,57 @@
 
   <detectors>
     <detector name="Tracker" type="LUXETracker" readout="SiHits" insideTrackingVolume="true">
-      <layer id="1" x="290*mm" y="0" z="3956*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      <layer id="1" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position"
+             dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="Tracker_stave_z_offset" x_offset="-Tracker_stave_x_offset"/>
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="-Tracker_stave_z_offset" x_offset="Tracker_stave_x_offset"/>
+        <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
+                width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
-      <layer id="2" x="290*mm" y="0" z="4056*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      <layer id="2" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + Tracker_layer_distance"
+             dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="Tracker_stave_z_offset" x_offset="-Tracker_stave_x_offset"/>
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="-Tracker_stave_z_offset" x_offset="Tracker_stave_x_offset"/>
+        <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
+                width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
-      <layer id="3" x="290*mm" y="0" z="4156*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      <layer id="3" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + 2*Tracker_layer_distance"
+             dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="Tracker_stave_z_offset" x_offset="-Tracker_stave_x_offset"/>
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="-Tracker_stave_z_offset" x_offset="Tracker_stave_x_offset"/>
+        <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
+                width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
-      <layer id="4" x="290*mm" y="0" z="4256*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
-        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
-        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      <layer id="4" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + 3*Tracker_layer_distance"
+             dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="Tracker_stave_z_offset" x_offset="-Tracker_stave_x_offset"/>
+        <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
+               length="Tracker_stave_length" width="Tracker_stave_width"
+               nmodules="Tracker_modules_per_stave" gap="Tracker_stave_gap"
+               z_offset="-Tracker_stave_z_offset" x_offset="Tracker_stave_x_offset"/>
+        <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
+                width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
     </detector>
   </detectors>

--- a/compact/LUXE/Tracker/Tracker_v0.xml
+++ b/compact/LUXE/Tracker/Tracker_v0.xml
@@ -1,0 +1,56 @@
+<lccdd>
+  <define>
+    <include ref="./tracker_defs.xml"/>
+  </define>
+
+  <detectors>
+    <detector name="Tracker" type="LUXETracker" readout="SiHits" insideTrackingVolume="true">
+      <layer id="1" x="290*mm" y="0" z="3956*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
+        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      </layer>
+      <layer id="2" x="290*mm" y="0" z="4056*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
+        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      </layer>
+      <layer id="3" x="290*mm" y="0" z="4156*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
+        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      </layer>
+      <layer id="4" x="290*mm" y="0" z="4256*mm" dx="500*mm" dy="15*mm" dz="20*mm" vis="Red">
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="6.*mm" x_offset="-115.*mm"/>
+        <stave material="CarbonFiber" thickness="0.1*mm" length="270*mm" width="15*mm" nmodules="9" gap="0.1*mm" z_offset="-6*mm" x_offset="115.*mm"/>
+        <sensor material="Si" thickness="0.1*mm" length="30*mm" width="15*mm" sensitive="true" vis="SolidRed"/>
+      </layer>
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="SiHits">
+      <segmentation type="CartesianGridXY" grid_size_x="0.025*mm" grid_size_y="0.025*mm"/>
+      <id>${GlobalTrackerReadoutID}</id>
+    </readout>
+  </readouts>
+
+  <plugins>
+    <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
+      <argument value="Tracker"/>
+      <argument value="dimension=2"/>
+      <argument value="u_x=1."/>
+      <argument value="v_y=1."/>
+      <argument value="n_z=1."/>
+    </plugin>
+    <plugin name="InstallSurfaceManager"/>
+  </plugins>
+
+  <display>
+    <vis name="SolidRed"  r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="Red"  alpha="0.1" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
+    <vis name="Invisible" showDaughters="true" visible="false"/>
+  </display>
+
+
+</lccdd>

--- a/compact/LUXE/Tracker/Tracker_v0.xml
+++ b/compact/LUXE/Tracker/Tracker_v0.xml
@@ -5,7 +5,7 @@
 
   <detectors>
     <detector name="Tracker" type="LUXETracker" readout="SiHits" insideTrackingVolume="true">
-      <layer id="1" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position"
+      <layer id="0" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position"
              dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
         <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
                length="Tracker_stave_length" width="Tracker_stave_width"
@@ -18,7 +18,7 @@
         <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
                 width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
-      <layer id="2" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + Tracker_layer_distance"
+      <layer id="1" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + Tracker_layer_distance"
              dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
         <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
                length="Tracker_stave_length" width="Tracker_stave_width"
@@ -31,7 +31,7 @@
         <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
                 width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
-      <layer id="3" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + 2*Tracker_layer_distance"
+      <layer id="2" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + 2*Tracker_layer_distance"
              dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
         <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
                length="Tracker_stave_length" width="Tracker_stave_width"
@@ -44,7 +44,7 @@
         <sensor material="Si" thickness="Tracker_sensor_thickness" length="Tracker_sensor_length"
                 width="Tracker_sensor_width" sensitive="true" vis="SolidRed"/>
       </layer>
-      <layer id="4" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + 3*Tracker_layer_distance"
+      <layer id="3" x="Tracker_x_pos_local" y="Tracker_y_position" z="Tracker_z_position + 3*Tracker_layer_distance"
              dx="Tracker_layer_dim_x" dy="Tracker_layer_dim_y" dz="Tracker_layer_dim_z" vis="Red">
         <stave material="CarbonFiber" thickness="Tracker_stave_thickness"
                length="Tracker_stave_length" width="Tracker_stave_width"

--- a/compact/LUXE/Tracker/Tracker_v0.xml
+++ b/compact/LUXE/Tracker/Tracker_v0.xml
@@ -35,22 +35,10 @@
     </readout>
   </readouts>
 
-  <plugins>
-    <plugin name="DD4hep_GenericSurfaceInstallerPlugin">
-      <argument value="Tracker"/>
-      <argument value="dimension=2"/>
-      <argument value="u_x=1."/>
-      <argument value="v_y=1."/>
-      <argument value="n_z=1."/>
-    </plugin>
-    <plugin name="InstallSurfaceManager"/>
-  </plugins>
-
   <display>
     <vis name="SolidRed"  r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="Red"  alpha="0.1" r="1.0" g="0.0" b="0.0" showDaughters="true" visible="true"/>
     <vis name="Invisible" showDaughters="true" visible="false"/>
   </display>
-
 
 </lccdd>

--- a/compact/LUXE/Tracker/tracker_defs.xml
+++ b/compact/LUXE/Tracker/tracker_defs.xml
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <define>
+  <constant name="Tracker_layer_distance" value="100*mm"/>
+  <constant name="Tracker_stave_length" value="270*mm"/>
+  <constant name="Tracker_stave_width" value="15*mm"/>
+  <constant name="Tracker_stave_thickness" value="0.1*mm"/>
+  <constant name="Tracker_stave_gap" value="0.1*mm"/>
+  <constant name="Tracker_stave_z_offset" value="6*mm"/>
+  <constant name="Tracker_stave_x_offset" value="115.*mm"/>
+  <constant name="Tracker_modules_per_stave" value="9"/>
+
+
+  <!-- TODO: These can probably be derived from other values? -->
+  <constant name="Tracker_layer_dim_x" value="500*mm"/>
+  <constant name="Tracker_layer_dim_y" value="15*mm"/>
+  <constant name="Tracker_layer_dim_z" value="20*mm"/>
+
+
+  <constant name="Tracker_x_pos_local" value="Tracker_x_position / 2 + Tracker_stave_length"/>
+
+  <constant name="Tracker_sensor_thickness" value="0.1*mm"/>
+  <constant name="Tracker_sensor_width" value="15*mm"/>
+  <constant name="Tracker_sensor_length" value="30*mm"/>
+
   <constant name="GlobalTrackerReadoutID"     type="string" value="system:1,side:1,layer:2,module:1,sensor:5,x:32:-16,y:-16"/>
 </define>
-

--- a/compact/LUXE/Tracker/tracker_defs.xml
+++ b/compact/LUXE/Tracker/tracker_defs.xml
@@ -11,10 +11,12 @@
 
 
   <!-- TODO: These can probably be derived from other values? -->
-  <constant name="Tracker_layer_dim_x" value="500*mm"/>
+  <!-- NOTE: dim_x was originally 500*mm but that makes the stave volume too
+       short, because it doesn't consider the gap between the sensors. that in
+       turn leads to a volume overlap with the outermost sensor volume. -->
+  <constant name="Tracker_layer_dim_x" value="502*mm"/>
   <constant name="Tracker_layer_dim_y" value="15*mm"/>
   <constant name="Tracker_layer_dim_z" value="20*mm"/>
-
 
   <constant name="Tracker_x_pos_local" value="Tracker_x_position / 2 + Tracker_stave_length"/>
 

--- a/compact/LUXE/Tracker/tracker_defs.xml
+++ b/compact/LUXE/Tracker/tracker_defs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<define>
+  <constant name="GlobalTrackerReadoutID"     type="string" value="system:1,side:1,layer:2,module:1,sensor:5,x:32:-16,y:-16"/>
+</define>
+

--- a/compact/LUXE/basic_defs.xml
+++ b/compact/LUXE/basic_defs.xml
@@ -8,6 +8,4 @@
 
   <constant name="tracker_region_zmax"        value="4300*mm"/>
   <constant name="tracker_region_rmax"        value="600*mm"/>
-
-  <constant name="GlobalTrackerReadoutID"     type="string" value="system:1,side:1,layer:2,module:1,sensor:5,x:32:-16,y:-16"/>
 </define>

--- a/compact/LUXE/basic_defs.xml
+++ b/compact/LUXE/basic_defs.xml
@@ -4,7 +4,7 @@
   <constant name="world_y"                value="world_side"/>
   <constant name="world_z"                value="world_side"/>
 
-  <constant name="env_safety" value="0.001"/>
+  <constant name="env_safety" value="0.1*mm"/>
 
   <constant name="tracker_region_zmax"        value="4300*mm"/>
   <constant name="tracker_region_rmax"        value="600*mm"/>

--- a/compact/LUXE/detector_positions.xml
+++ b/compact/LUXE/detector_positions.xml
@@ -1,8 +1,18 @@
 <define>
   <comment>
     Global detector positions that might have different values in the standalone
-    versions of the subdetectors
+    versions of the subdetectors.
+
+    The x-position of the tracker refers to the "point of closest approach" to
+    the beamline (in x and y). This might require some additional translation when
+    placing the subdetector depending on how it defines its local coordinate
+    system. For example, it might be that it defines (0, 0, 0) to be in the
+    center of the sub-detector with extents in all directions.
   </comment>
+
+  <constant name="Tracker_x_position" value="4 * cm"/>
+  <constant name="Tracker_y_position" value="0*mm"/>
+  <constant name="Tracker_z_position" value="3956*mm"/>
 
   <constant name="EcalP_x_position" value="10 * cm"/>
   <constant name="EcalP_y_position" value="0"/>

--- a/compact/LUXE/detector_positions.xml
+++ b/compact/LUXE/detector_positions.xml
@@ -1,0 +1,10 @@
+<define>
+  <comment>
+    Global detector positions that might have different values in the standalone
+    versions of the subdetectors
+  </comment>
+
+  <constant name="EcalP_x_position" value="10 * cm"/>
+  <constant name="EcalP_y_position" value="0"/>
+  <constant name="EcalP_z_position" value="4300 * mm"/>
+</define>

--- a/src/LUXETracker_geo.cpp
+++ b/src/LUXETracker_geo.cpp
@@ -13,10 +13,9 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
   PlacedVolume pv;
   sens.setType("tracker");
 
-  int n = 0;
-  for (xml_coll_t i(x_det, _U(layer)); i; ++i, ++n) {
+  for (xml_coll_t i(x_det, _U(layer)); i; ++i) {
     xml_comp_t x_layer = i;
-    string l_name = det_name + _toString(n, "_layer%d");
+    string l_name = det_name + _toString(x_layer.id(), "_layer%d");
     double x = x_layer.x();
     double y = x_layer.y();
     double z = x_layer.z();
@@ -24,7 +23,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     double dy = x_layer.dy();
     double dz = x_layer.dz();
 
-    DetElement layer(sdet, _toString(n, "layer%d"), x_layer.id());
+    DetElement layer(sdet, _toString(x_layer.id(), "layer%d"), x_layer.id());
     Box l_box(0.5 * dx, 0.5 * dy, 0.5 * dz);
     Volume l_vol(l_name, l_box, air);
 
@@ -76,7 +75,7 @@ static Ref_t create_detector(Detector& description, xml_h e, SensitiveDetector s
     l_vol.setVisAttributes(description, x_layer.visStr());
     assembly.setVisAttributes(description, x_det.visStr());
     pv = assembly.placeVolume(l_vol, Transform3D(Position(x, y, z)));
-    pv.addPhysVolID("layer", n);
+    pv.addPhysVolID("layer", x_layer.id());
     layer.setPlacement(pv);
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,3 +47,10 @@ LUXEGEO_TEST(test_ECALe
   --gun.position=0,0,-250 --gun.direction=0,0,1
   --outputFile ddsim_luxe_ecale.root
 )
+
+LUXEGEO_TEST(test_LUXE_v0
+  ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/LUXE/LUXE_v0.xml
+  -G -N 1 --gun.multiplicity 100 --gun.particle e-
+  --outputFile ddsim_luxe_v0.root
+
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,3 +54,8 @@ LUXEGEO_TEST(test_LUXE_v0
   --outputFile ddsim_luxe_v0.root
 
 )
+
+LUXEGEO_TEST(overlap_check_LUXE_v0
+  ddsim --compactFile ${CMAKE_SOURCE_DIR}/compact/LUXE/LUXE_v0.xml
+  --runType run --ui.commandsInitialize "/geometry/test/run"
+)


### PR DESCRIPTION
This introduces
-  a `LUXE_v0` geometry that includes that `LUXETracker` as tracker and the `ECALp_2512` as ECAL on the positron side.
- overlap checks for the `LUXE_v0` geometry as a test case

The `LUXETracker` and `ECALp` geometries are split such that they can still be run standalone with the same detector description as is used in the `LUXE_v0` geometry; Esentially `ECALp_2512` and `LUXETracker` just become wrappers with the necessary includes and the interesting bits are now in `ECALp_v0` and  `Tracker_v0`.

---- 
- [x] Includes #9 
- [x] Includes #10 
- [ ] Check all dimensions
- [x] Define some of the "magic numbers" as global constants
- [x] Fix overlaps